### PR TITLE
🔨 Add Cloudflare Pages docs deploy (parallel to RtD)

### DIFF
--- a/.github/workflows/deploy-docs-cf.yml
+++ b/.github/workflows/deploy-docs-cf.yml
@@ -1,0 +1,54 @@
+name: Deploy docs to Cloudflare Pages
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-docs-cf-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Override site_url for the Cloudflare build
+        run: |
+          sed -i 's|^site_url = .*|site_url = "https://docs-cf.owid.io/projects/owid-grapher-py/"|' zensical.toml
+
+      - name: Build docs
+        run: make docs.build
+
+      - name: Stage build under /projects/owid-grapher-py/
+        run: |
+          mkdir -p staging/projects/owid-grapher-py
+          cp -a site/. staging/projects/owid-grapher-py/
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: >-
+            pages deploy staging
+            --project-name=owid-grapher-py-docs
+            --branch=${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
> _Written by Claude Code — @lucasrodes at the wheel._

Stands up a parallel Cloudflare Pages deploy for these docs at `https://docs-cf.owid.io/projects/owid-grapher-py/`, alongside the existing RtD build (untouched). Mirrors the pattern used in [owid/etl](https://github.com/owid/etl/pull/6148) and [owid/owid-docs](https://github.com/owid/owid-docs/pull/2).

| | |
|---|---|
| Workflow | `.github/workflows/deploy-docs-cf.yml` |
| CF project | `owid-grapher-py-docs` (Direct Upload, production branch = `master`) |
| Staging URL | `https://docs-cf.owid.io/projects/owid-grapher-py/` (after the umbrella router learns about this project) |
| Direct project URL | `https://owid-grapher-py-docs.pages.dev/projects/owid-grapher-py/` |
| RtD | unchanged |

### Manual setup

1. Create the Pages project:
   ```bash
   npx wrangler pages project create owid-grapher-py-docs --production-branch=master
   ```
2. Add repo secrets `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` (same values as in the etl and owid-docs repos).
3. Merge this PR → workflow deploys to `owid-grapher-py-docs.pages.dev/projects/owid-grapher-py/`.
4. Add the matching route to the umbrella router in `owid/owid-docs#2`'s `_worker.js` (PR follow-up sent in that repo).