### PR TITLE
🐛 Fix API Reference page (drop dead mkdocstrings refs)

### DIFF
--- a/docs/api-reference/grapher.md
+++ b/docs/api-reference/grapher.md
@@ -1,7 +1,3 @@
 ::: owid.grapher.Chart
 
-::: owid.grapher.ChartConfig
-
-::: owid.grapher.Dimension
-
 ::: owid.grapher.TimeType


### PR DESCRIPTION
> _Written by Claude Code — @lucasrodes at the wheel._

`docs/api-reference/grapher.md` referenced `owid.grapher.ChartConfig` and `owid.grapher.Dimension`, neither of which exist in the package anymore. mkdocstrings errors out trying to collect them — the build "succeeds" green (Zensical isn't run in strict mode here) but the page is silently skipped, so the **API Reference** top-bar link in the published docs goes nowhere.

Build log from the last deploy:

```
mkdocstrings: owid.grapher.ChartConfig could not be found
Error: PluginError: Could not collect 'owid.grapher.ChartConfig'
```

Keeping the two refs that do resolve (`Chart`, `TimeType`). If other public classes should be in the reference (e.g. `GrapherState`, `VariableConfig`, the re-exports from `grapher_state`), happy to add them in a follow-up — felt cleaner to keep this PR to the bug fix.

### How to verify after merge

- Wait for the CF deploy workflow to land on `master`.
- Visit https://docs-cf.owid.io/projects/owid-grapher-py/ → click **API Reference** in the top bar → should land on `/api-reference/grapher/` and render the `Chart` and `TimeType` docs.