### PR TITLE
🔨 Point docs site_url at docs.owid.io for the CF cut-over

### DIFF
--- a/.github/workflows/deploy-docs-cf.yml
+++ b/.github/workflows/deploy-docs-cf.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Override site_url for the Cloudflare build
         run: |
-          sed -i 's|^site_url = .*|site_url = "https://docs-cf.owid.io/projects/owid-grapher-py/"|' zensical.toml
+          sed -i 's|^site_url = .*|site_url = "https://docs.owid.io/projects/owid-grapher-py/"|' zensical.toml
 
       - name: Build docs
         run: make docs.build


### PR DESCRIPTION
> _Written by Claude Code — @lucasrodes at the wheel._

Part of the RtD → CF Pages cut-over (owid/etl#6151). Changes the `site_url` sed-override in the CF deploy workflow from `docs-cf.owid.io` to `docs.owid.io`. Safe to merge before the DNS swap — both hosts serve the same content paths today.