### PR TITLE
✨ Support multi-indicator charts (list-valued y)

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,9 @@ Auto-generate more types of notebooks correctly
 
 ## Changelog
 
+- `0.3.3`
+    - Support multi-indicator charts: `encode()` and `plot()` accept a list of `y` columns, drawing each as a separate series (line/area charts)
+    - Default the selection for multi-indicator charts to a single reference entity (`World`, else the best-covered entities) to avoid entities × indicators overload
 - `0.3.2`
     - Add `to_html()` method for getting standalone HTML
 - `0.3.1`

--- a/owid/grapher/__init__.py
+++ b/owid/grapher/__init__.py
@@ -1309,17 +1309,17 @@ def _default_multi_indicator_entities(
     reference entity ("World") when present; otherwise fall back to the ``n`` entities
     with the most data. Deterministic, so the same call always renders the same chart.
     """
-    entities = list(df[entity_col].dropna().unique())
+    values = list(df[entity_col].dropna())
+    entities = list(dict.fromkeys(values))  # unique, preserving first-seen order
     if "World" in entities:
         return ["World"]
-    counts = (
-        df.dropna(subset=[entity_col])
-        .groupby(entity_col)
-        .size()
-        .sort_values(ascending=False, kind="mergesort")
-    )
-    chosen = list(counts.head(n).index)
-    return chosen or entities[:n]
+    # rank by data coverage (row count), deterministic on ties via the entity name.
+    # done in plain Python to avoid pandas groupby/sort_values typing ambiguity.
+    counts: Dict[Any, int] = {}
+    for v in values:
+        counts[v] = counts.get(v, 0) + 1
+    ranked = sorted(entities, key=lambda e: (-counts[e], str(e)))
+    return ranked[:n]
 
 
 def plot(

--- a/owid/grapher/__init__.py
+++ b/owid/grapher/__init__.py
@@ -122,7 +122,7 @@ class Chart:
     def encode(
         self,
         x: Optional[str] = None,
-        y: Optional[Union[str, List[str]]] = None,
+        y: Optional[Union[str, List[str], Tuple[str, ...]]] = None,
         y_lower: Optional[str] = None,
         y_upper: Optional[str] = None,
         entity: Optional[str] = None,
@@ -755,6 +755,19 @@ class Chart:
         y_cols: List[str]
         selected_entities: List[str]
 
+        # Multi-indicator y only makes sense where series share a value axis (line/area).
+        # Scatter and discrete-bar charts would silently use just the first column, so
+        # reject a list there instead of dropping the rest.
+        if self.y_extra and chart_type in (
+            "ScatterPlot",
+            "DiscreteBar",
+            "StackedDiscreteBar",
+        ):
+            raise ValueError(
+                f"a list of y columns (multi-indicator) is supported for line/area "
+                f"charts, not {chart_type}"
+            )
+
         if chart_type == "ScatterPlot":
             y_cols = [x_col, y_col]  # Both are "value" columns for scatter
             if self.selection is None:
@@ -1327,7 +1340,7 @@ def plot(
     *,
     # Column mappings
     x: str = "year",
-    y: Union[str, List[str]],
+    y: Union[str, List[str], Tuple[str, ...]],
     y_lower: Optional[str] = None,
     y_upper: Optional[str] = None,
     entity: str = "entity",

--- a/owid/grapher/__init__.py
+++ b/owid/grapher/__init__.py
@@ -11,7 +11,7 @@ import re
 import string
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, List, Literal, Optional, Tuple
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 import pandas as pd
 from dateutil.parser import parse
@@ -106,6 +106,7 @@ class Chart:
         )
         self.x: Optional[str] = None
         self.y: Optional[str] = None
+        self.y_extra: List[str] = []  # additional y indicators (multi-indicator charts)
         self.y_lower: Optional[str] = None  # Lower bound for confidence intervals
         self.y_upper: Optional[str] = None  # Upper bound for confidence intervals
         self.entity: Optional[str] = None
@@ -121,7 +122,7 @@ class Chart:
     def encode(
         self,
         x: Optional[str] = None,
-        y: Optional[str] = None,
+        y: Optional[Union[str, List[str]]] = None,
         y_lower: Optional[str] = None,
         y_upper: Optional[str] = None,
         entity: Optional[str] = None,
@@ -139,8 +140,10 @@ class Chart:
         Args:
             x: Column name for x-axis. For line/bar charts, typically a time column
                 ('year', 'date'). For scatter plots, a numeric value column.
-            y: Column name for y-axis values to plot. For bar charts, can be the entity
-                column if you want entities on the y-axis.
+            y: Column name(s) for y-axis values to plot. Pass a list of columns to draw
+                several indicators as separate series on one chart (multi-indicator); they
+                share one y-axis, so use comparable/same-unit indicators. For bar charts,
+                can be the entity column if you want entities on the y-axis.
             y_lower: Column name for lower bound of confidence interval. When specified
                 along with y_upper, renders a shaded confidence band around the main line.
             y_upper: Column name for upper bound of confidence interval. When specified
@@ -185,7 +188,13 @@ class Chart:
             ```
         """
         self.x = x
-        self.y = y
+        # y may be a single column or a list of columns (multi-indicator → one series each)
+        if isinstance(y, (list, tuple)):
+            self.y = y[0] if len(y) else None
+            self.y_extra = list(y[1:])
+        else:
+            self.y = y
+            self.y_extra = []
         self.y_lower = y_lower
         self.y_upper = y_upper
         self.entity = entity
@@ -193,7 +202,7 @@ class Chart:
         self.size = size
 
         # fail early if there's been a typo
-        for col in [x, y, y_lower, y_upper, entity, color, size]:
+        for col in [x, self.y, *self.y_extra, y_lower, y_upper, entity, color, size]:
             if col and col not in self.data.columns:
                 raise ValueError(f"no such column: {col}")
 
@@ -772,6 +781,9 @@ class Chart:
         else:
             # Line charts: x is time, y is value, entity is grouping
             y_cols = [y_col]
+            # Additional y indicators (multi-indicator charts) → one extra series each
+            for ey in self.y_extra:
+                y_cols.append(rename_map.get(ey, ey))
             # Add confidence interval columns if specified
             if self.y_lower:
                 y_lower_col = rename_map.get(self.y_lower, self.y_lower)
@@ -781,7 +793,14 @@ class Chart:
                 y_cols.append(y_upper_col)
             if self.selection is None:
                 if entity_col:
-                    selected_entities = list(df[entity_col].unique())
+                    # entities x indicators is unreadable with several indicators, so
+                    # default to a single reference entity instead of every entity.
+                    if self.y_extra:
+                        selected_entities = _default_multi_indicator_entities(
+                            df, entity_col
+                        )
+                    else:
+                        selected_entities = list(df[entity_col].unique())
                 else:
                     selected_entities = [y_col]  # Use column name as entity
             else:
@@ -1281,12 +1300,34 @@ PlotType = Literal["map", "line", "bar", "slope", "marimekko", "scatter", "stack
 VariableConfigDict = Dict[str, Any]
 
 
+def _default_multi_indicator_entities(
+    df: pd.DataFrame, entity_col: str, n: int = 5
+) -> List[str]:
+    """Pick a default entity selection for multi-indicator charts.
+
+    Showing every entity times every indicator is unreadable, so prefer a single
+    reference entity ("World") when present; otherwise fall back to the ``n`` entities
+    with the most data. Deterministic, so the same call always renders the same chart.
+    """
+    entities = list(df[entity_col].dropna().unique())
+    if "World" in entities:
+        return ["World"]
+    counts = (
+        df.dropna(subset=[entity_col])
+        .groupby(entity_col)
+        .size()
+        .sort_values(ascending=False, kind="mergesort")
+    )
+    chosen = list(counts.head(n).index)
+    return chosen or entities[:n]
+
+
 def plot(
     data: pd.DataFrame,
     *,
     # Column mappings
     x: str = "year",
-    y: str,
+    y: Union[str, List[str]],
     y_lower: Optional[str] = None,
     y_upper: Optional[str] = None,
     entity: str = "entity",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "owid-grapher-py"
-version = "0.3.2"
+version = "0.3.3"
 description = "OWID charts for rendering in Jupyter notebooks."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/test_grapher.py
+++ b/tests/test_grapher.py
@@ -664,3 +664,70 @@ def test_plot_wrapper_entity_selection():
 
     # Check entity selection
     assert config["selectedEntityNames"] == ["USA", "UK"]
+
+
+def test_multi_indicator_line_chart():
+    # Several same-unit indicators drawn as separate series on one chart.
+    df = pd.DataFrame(
+        {
+            "year": [2000, 2010, 2020],
+            "entity": ["World"] * 3,
+            "coal": [40, 33, 26],
+            "gas": [20, 23, 26],
+            "renewables": [5, 16, 27],
+        }
+    )
+    ch = (
+        gr.Chart(df)
+        .mark_line()
+        .encode(x="year", y=["coal", "gas", "renewables"], entity="entity")
+    )
+    export = ch.export()
+    config = export["grapher_config"]
+
+    # All three indicators become y-slugs (one series each)
+    assert config["ySlugs"] == "coal gas renewables"
+    slugs = {c["slug"] for c in export["column_defs"]}
+    assert {"coal", "gas", "renewables"} <= slugs
+
+
+def test_multi_indicator_via_plot():
+    df = pd.DataFrame(
+        {
+            "year": [2000, 2010, 2020],
+            "entity": ["World"] * 3,
+            "coal": [40, 33, 26],
+            "gas": [20, 23, 26],
+        }
+    )
+    config = gr.plot(df, y=["coal", "gas"]).export()["grapher_config"]
+    assert config["ySlugs"] == "coal gas"
+
+
+def test_multi_indicator_defaults_to_world():
+    # Many entities x several indicators is unreadable, so default to a reference entity.
+    df = pd.DataFrame(
+        {
+            "year": [2000, 2010] * 3,
+            "entity": ["USA", "USA", "UK", "UK", "World", "World"],
+            "a": [1, 2, 3, 4, 5, 6],
+            "b": [6, 5, 4, 3, 2, 1],
+        }
+    )
+    ch = gr.Chart(df).mark_line().encode(x="year", y=["a", "b"], entity="entity")
+    config = ch.export()["grapher_config"]
+    assert config["selectedEntityNames"] == ["World"]
+
+
+def test_single_indicator_selection_unchanged():
+    # Single-y behaviour must be unaffected: still selects all entities by default.
+    df = pd.DataFrame(
+        {
+            "year": [2000, 2010] * 2,
+            "entity": ["USA", "USA", "UK", "UK"],
+            "population": [1, 2, 3, 4],
+        }
+    )
+    ch = gr.Chart(df).mark_line().encode(x="year", y="population", entity="entity")
+    config = ch.export()["grapher_config"]
+    assert set(config["selectedEntityNames"]) == {"USA", "UK"}

--- a/tests/test_grapher.py
+++ b/tests/test_grapher.py
@@ -5,6 +5,7 @@
 #
 
 import pandas as pd
+import pytest
 
 import owid.grapher as gr
 
@@ -731,3 +732,18 @@ def test_single_indicator_selection_unchanged():
     ch = gr.Chart(df).mark_line().encode(x="year", y="population", entity="entity")
     config = ch.export()["grapher_config"]
     assert set(config["selectedEntityNames"]) == {"USA", "UK"}
+
+
+def test_multi_indicator_rejected_for_bar():
+    # A list of y on a discrete-bar chart should fail loudly, not silently drop columns.
+    df = pd.DataFrame(
+        {
+            "year": [2000, 2010],
+            "entity": ["World", "World"],
+            "a": [1, 2],
+            "b": [3, 4],
+        }
+    )
+    ch = gr.Chart(df).mark_bar().encode(x="year", y=["a", "b"], entity="entity")
+    with pytest.raises(ValueError):
+        ch.export()


### PR DESCRIPTION
## Human summary for context

Hey @Marigold I realised that, to be able to play around with Claude to create static visualizations of data that doesn't already live in grapher charts, it would be useful to use `owid-grapher-py`. However, I noticed that it currently doesn't seem to allow using multiple indicators. Do you see any strong reason why that's the case? Otherwise, this PR changes that to allow for multiple indicators.

---

> _Written by Claude Code — @pabloarosado at the wheel._

## What

`encode()` and `plot()` now accept a **list of columns** for `y`, drawing each as its own series on one chart — i.e. multi-indicator charts. Previously `y` was a single column, and the only multi-series option was multiple *entities*.

```python
# before: only one indicator, or many entities of one indicator
plot(df, y="coal", entity="entity")

# now: several indicators as separate series
plot(df, y=["coal", "gas", "renewables"], entity="entity")
```

## Why it's a small change

The rendering machinery already handled multiple y columns — grapher's `ySlugs` is space-joined from all of them, and per-column display name / colour / unit already flow through `_build_column_defs` (the confidence-interval feature already renders 3 columns as 3 series). The only blocker was the public `y` parameter being a single `str`. So this just routes the extra columns into the existing `y_cols` path.

**No `owid-grapher` change is needed** — multiple y-variables is core grapher; verified by rendering a 3-indicator chart through the unmodified grapher bundle.

## Entity default

Many entities × several indicators is unreadable, so when no selection is given a multi-indicator chart defaults to a single reference entity (`World`, else the best-covered entities, deterministically). **Single-`y` behaviour is unchanged.**

## Caveat

All y series share one y-axis, so this is for **comparable / same-unit** indicators (e.g. electricity by source in %, male/female life expectancy in years). Mixing units on one axis would mislead.

## Tests

Added `test_multi_indicator_line_chart`, `test_multi_indicator_via_plot`, `test_multi_indicator_defaults_to_world`, and `test_single_indicator_selection_unchanged`. Full suite: 27 passed. Also rendered a real 3-line SVG via the grapher bundle to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)