### PR TITLE
🔨 Switch PyPI publish workflow to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,19 +8,29 @@ on:
       - 'pyproject.toml'
   workflow_dispatch:
 
-jobs:
-  publish:
-    runs-on: ubuntu-latest
+permissions:
+  contents: read
 
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      should_publish: ${{ steps.version-check.outputs.should_publish }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         fetch-depth: 2
 
     - name: Check if version was bumped
       id: version-check
       run: |
+        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          echo "Manual dispatch, forcing publish"
+          echo "should_publish=true" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
         CURRENT_VERSION=$(grep '^version = ' pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
         PREVIOUS_VERSION=$(git show HEAD~1:pyproject.toml 2>/dev/null | grep '^version = ' | head -1 | sed 's/version = "\(.*\)"/\1/' || echo "")
 
@@ -35,22 +45,31 @@ jobs:
           echo "should_publish=true" >> $GITHUB_OUTPUT
         fi
 
+  publish:
+    needs: check
+    if: needs.check.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
     - name: Set up Python
-      if: steps.version-check.outputs.should_publish == 'true'
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
-        python-version: '3.12'
+        python-version: '3.x'
 
-    - name: Install UV
-      if: steps.version-check.outputs.should_publish == 'true'
-      run: curl -LsSf https://astral.sh/uv/install.sh | sh
+    - name: Set up uv
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
 
-    - name: Build and publish
-      if: steps.version-check.outputs.should_publish == 'true'
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.POETRY_PYPI_TOKEN_PYPI }}
+    - name: Build
       run: |
         rm -rf dist
         uv build
-        uvx twine upload dist/*
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0


### PR DESCRIPTION
## Why

Publishing to PyPI started failing with `403 Forbidden` (see the failed run on #29's merge to master). The cause: this repo's **repo-level** `POETRY_PYPI_TOKEN_PYPI` secret was a copy of the org PyPI API token, which was **revoked** when etl migrated to Trusted Publishing in owid/etl@43d4bcc (2026-05-13). owid-grapher-py was never migrated, so it kept presenting a dead token.

Rather than mint another long-lived token, this migrates the repo to Trusted Publishing (OIDC) — the same approach etl now uses.

## What changed

- Drop the `twine` + `POETRY_PYPI_TOKEN_PYPI` flow; publish via pinned `pypa/gh-action-pypi-publish` using a short-lived OIDC token (PEP 740 attestations emitted automatically).
- Split into `check` → `publish` jobs so the protected `environment: pypi` only spins up on an actual version bump.
- `publish` job gets `permissions: id-token: write` (+ baseline `contents: read`).
- `workflow_dispatch` forces a publish — lets us manually recover the stuck **0.3.3** (it 403'd and was never published; PyPI latest is still 0.3.2).
- Pin all actions to commit SHAs; replace `curl | sh` uv installer with `astral-sh/setup-uv`.

## Required PyPI/GitHub config (done out-of-band)

- Trusted publisher on PyPI for `owid-grapher-py` → workflow `publish.yml`, environment `pypi`.
- GitHub `pypi` environment created.

## Cleanup after merge

- The repo-level `POETRY_PYPI_TOKEN_PYPI` secret is now unused and can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)